### PR TITLE
Implement agent.ExtendedAgent

### DIFF
--- a/agent/shimagent/agent.go
+++ b/agent/shimagent/agent.go
@@ -11,7 +11,7 @@ import (
 // ShimAgent is an interface that extends the functionality
 // of the Agent interface in golang.org/x/crypto/ssh/agent.
 type ShimAgent interface {
-	agent.Agent
+	agent.ExtendedAgent
 
 	// Forward is prepared for unknown OpenSSH request,
 	// it will simply forward the request to the ssh-agent.

--- a/agent/yubiagent/mock_shimagent_test.go
+++ b/agent/yubiagent/mock_shimagent_test.go
@@ -77,6 +77,21 @@ func (mr *MockShimAgentMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockShimAgent)(nil).Close))
 }
 
+// Extension mocks base method.
+func (m *MockShimAgent) Extension(arg0 string, arg1 []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Extension", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Extension indicates an expected call of Extension.
+func (mr *MockShimAgentMockRecorder) Extension(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extension", reflect.TypeOf((*MockShimAgent)(nil).Extension), arg0, arg1)
+}
+
 // Forward mocks base method.
 func (m *MockShimAgent) Forward(arg0 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -162,6 +177,21 @@ func (m *MockShimAgent) Sign(arg0 ssh.PublicKey, arg1 []byte) (*ssh.Signature, e
 func (mr *MockShimAgentMockRecorder) Sign(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockShimAgent)(nil).Sign), arg0, arg1)
+}
+
+// SignWithFlags mocks base method.
+func (m *MockShimAgent) SignWithFlags(arg0 ssh.PublicKey, arg1 []byte, arg2 agent.SignatureFlags) (*ssh.Signature, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SignWithFlags", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*ssh.Signature)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignWithFlags indicates an expected call of SignWithFlags.
+func (mr *MockShimAgentMockRecorder) SignWithFlags(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignWithFlags", reflect.TypeOf((*MockShimAgent)(nil).SignWithFlags), arg0, arg1, arg2)
 }
 
 // Signers mocks base method.


### PR DESCRIPTION
This allows providing rsa-sha2-512 and rsa-sha2-256 signatures; see https://github.com/golang/crypto/commit/dab2b1051b5dd33a57e97c4774ed152e6a6c9a13.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
