### PR TITLE
Use init to ensure otel meter is initialized

### DIFF
--- a/cmd/gensign/main.go
+++ b/cmd/gensign/main.go
@@ -111,7 +111,6 @@ func main() {
 				fileLogger.Warn().Err(err).Msg("failed to shut down oTel provider")
 			}
 		}()
-		gensign.InitOTelMeter()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), conf.RequestTimeout)

--- a/gensign/otel.go
+++ b/gensign/otel.go
@@ -21,8 +21,8 @@ const (
 
 var meter metric.Meter
 
-// InitOTelMeter initializes the oTel meter for ysshra.
-func InitOTelMeter() {
+// init ensures the oTel meter for ysshra is initialized.
+func init() {
 	meter = otel.GetMeterProvider().Meter(scopeName)
 }
 


### PR DESCRIPTION
To avoid panic if the meter is unset.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
