### PR TITLE
Client traceId logic added per request

### DIFF
--- a/csr/param.go
+++ b/csr/param.go
@@ -38,8 +38,7 @@ type ReqParam struct {
 	ReqUser string
 	// ReqHost is the user host name that sends request to RA.
 	ReqHost string
-	// TransID stands for transaction ID and serves as the unique identifier for a request.
-	// It should be generated on server-side right after receiving client request.
+	// TransID is the unique identifier for a request: server-generated, optionally prefixed by the client traceId from Attributes when present.
 	TransID string
 	// SSHClientVersion is the version of the SSH Client.
 	SSHClientVersion version.Version
@@ -85,6 +84,12 @@ func NewReqParam(envGetter func(string) string, osArgsGetter func() []string) (*
 		}
 	}
 
+	serverTransID := transid.Generate()
+	transID := serverTransID
+	if tid := strings.TrimSpace(reqAttrs.TraceID); tid != "" {
+		transID = tid + "-" + serverTransID
+	}
+
 	return &ReqParam{
 		NamespacePolicy:  namespacePolicy,
 		HandlerName:      handlerName,
@@ -92,7 +97,7 @@ func NewReqParam(envGetter func(string) string, osArgsGetter func() []string) (*
 		LogName:          logName,
 		ReqUser:          reqAttrs.Username,
 		ReqHost:          reqAttrs.Hostname,
-		TransID:          transid.Generate(),
+		TransID:          transID,
 		SSHClientVersion: sshClientVersion,
 		SignatureAlgo:    x509.SignatureAlgorithm(reqAttrs.SignatureAlgo),
 		Attrs:            reqAttrs,

--- a/csr/param_test.go
+++ b/csr/param_test.go
@@ -6,6 +6,7 @@ package csr
 import (
 	"crypto/x509"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/theparanoids/ysshra/common"
@@ -126,6 +127,65 @@ func TestNewReqParam(t *testing.T) {
 				t.Fatalf("%s: want: %+v, got: %+v", name, test.expectedReqParam, param)
 			}
 		})
+	}
+}
+
+func TestNewReqParam_ClientTraceID(t *testing.T) {
+	t.Parallel()
+	envGetter := func(s string) string {
+		cmd := `{"exts":{"field1":"value1"},"hardKey":true,"hostname":"host.com","ifVer":7,"signatureAlgo":3,"sshClientVersion":"8.1","touch2SSH":false,"traceId":"trace_id_0123456789abcdef0123","username":"user"}`
+		m := map[string]string{
+			"SSH_CONNECTION":       "1.2.3.4 36673 192.168.223.229 22",
+			"LOGNAME":              "user",
+			"SSH_ORIGINAL_COMMAND": cmd,
+		}
+		return m[s]
+	}
+	osArgsGetter := func() []string {
+		return []string{"/usr/bin/gen-sign", "NONS", "Regular"}
+	}
+	param, err := NewReqParam(envGetter, osArgsGetter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPrefix := "trace_id_0123456789abcdef0123-"
+	if !strings.HasPrefix(param.TransID, wantPrefix) {
+		t.Fatalf("TransID prefix: got %q", param.TransID)
+	}
+	suffix := strings.TrimPrefix(param.TransID, wantPrefix)
+	if len(suffix) != 10 {
+		t.Fatalf("server trans id suffix: want len 10, got %d (%q)", len(suffix), suffix)
+	}
+	if param.Attrs.TraceID != "trace_id_0123456789abcdef0123" {
+		t.Fatalf("Attrs.TraceID: got %q", param.Attrs.TraceID)
+	}
+}
+
+func TestNewReqParam_ArbitraryTraceIDCombined(t *testing.T) {
+	t.Parallel()
+	envGetter := func(s string) string {
+		cmd := `{"hardKey":true,"hostname":"host.com","ifVer":7,"signatureAlgo":3,"sshClientVersion":"8.1","touch2SSH":false,"traceId":"my-custom-trace","username":"user"}`
+		m := map[string]string{
+			"SSH_CONNECTION":       "1.2.3.4 36673 192.168.223.229 22",
+			"LOGNAME":              "user",
+			"SSH_ORIGINAL_COMMAND": cmd,
+		}
+		return m[s]
+	}
+	osArgsGetter := func() []string {
+		return []string{"/usr/bin/gen-sign", "NONS", "Regular"}
+	}
+	param, err := NewReqParam(envGetter, osArgsGetter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPrefix := "my-custom-trace-"
+	if !strings.HasPrefix(param.TransID, wantPrefix) {
+		t.Fatalf("TransID prefix: got %q", param.TransID)
+	}
+	suffix := strings.TrimPrefix(param.TransID, wantPrefix)
+	if len(suffix) != 10 {
+		t.Fatalf("server trans id suffix: want len 10, got %d (%q)", len(suffix), suffix)
 	}
 }
 

--- a/message/attrs.go
+++ b/message/attrs.go
@@ -24,6 +24,8 @@ type Attributes struct {
 	CAPubKeyAlgo x509.PublicKeyAlgorithm `json:"caPubKeyAlgo,omitempty"`
 	// SignatureAlgo is the signing algorithm of the requested certificate. (Not implemented.)
 	SignatureAlgo x509.SignatureAlgorithm `json:"signatureAlgo,omitempty"`
+	// TraceID is an optional client-supplied string; when non-empty the server prepends it to TransID.
+	TraceID string `json:"traceId,omitempty"`
 	// HardKey indicates whether the request is associated to a public key backed in a smartcard hardware.
 	HardKey bool `json:"hardKey"`
 	// Touch2SSH indicates whether the requested certificate requires a touch during SSH login challenge.


### PR DESCRIPTION
Each YINIT request gets a server-only `transID` in the RA server. That makes it hard to tie a client run to RA logs and other systems (e.g. SPHelp) when debugging failures.
Clients can now send an optional `traceId` in the gensign JSON attributes. When present, the RA combines it with the existing server-generated ID instead of replacing server identity.
