### PR TITLE
Skip slave Remove for in-memory HardCerts to preserve PKCS11 keys

### DIFF
--- a/agent/shimagent/shimserver.go
+++ b/agent/shimagent/shimserver.go
@@ -189,19 +189,20 @@ func newShimAgent(conn io.ReadWriteCloser, noUpstream bool) (*Server, error) {
 func (s *Server) remove(key ssh.PublicKey) error {
 	removed := false
 
-	// Remove the in-memory certificates.
+	// Remove the in-memory certificates (HardCerts from AddHardCert live only here).
 	h := hash(key.Marshal())
 	if _, ok := s.certs[h]; ok {
 		delete(s.certs, h)
 		removed = true
 	}
 
-	// Remove the in-agent key.
-	err := s.agent.Remove(key)
-	// If the public key is from the in-memory certificate, it returns a not found error from the
-	// underlying agent.
-	if err != nil && !removed {
-		return err
+	// HardCerts are stored only in s.certs, not in the underlying agent. Forwarding
+	// their Remove to Windows OpenSSH drops the matching PKCS11 bare key and breaks
+	// subsequent AddHardCert. Skip the slave Remove when we already cleared memory.
+	if !removed {
+		if err := s.agent.Remove(key); err != nil {
+			return err
+		}
 	}
 
 	if s.noUpstreamSSHCACert {

--- a/agent/shimagent/shimserver_test.go
+++ b/agent/shimagent/shimserver_test.go
@@ -129,11 +129,22 @@ func TestServer_filter(t *testing.T) {
 					return err
 				}
 
+				// Expired identity only in the underlying agent (not a HardCert in s.certs).
 				if err := s.Add(ag.AddedKey{PrivateKey: priv, Certificate: certExpired, Comment: "expired"}); err != nil {
 					return err
 				}
 
-				if err := s.AddHardCert(certExpired, "expired"); err != nil {
+				// Expired HardCert only in shim memory (AddHardCert never stores the cert in the slave).
+				certExpiredHard := &ssh.Certificate{
+					Key:         signer.PublicKey(),
+					KeyId:       "expired-hardcert",
+					ValidAfter:  uint64(now.Add(-time.Hour).Unix()),
+					ValidBefore: uint64(now.Add(-time.Minute).Unix()),
+				}
+				if err := certExpiredHard.SignCert(rand.Reader, signer); err != nil {
+					return err
+				}
+				if err := s.AddHardCert(certExpiredHard, "expired"); err != nil {
 					return err
 				}
 
@@ -1306,5 +1317,129 @@ func TestServer_Sign(t *testing.T) {
 					cmp.Diff(keys, tt.wantKeys))
 			}
 		})
+	}
+}
+
+// countingAgent wraps an agent.Agent and counts Remove calls.
+type countingAgent struct {
+	ag.Agent
+	removeCalls int
+}
+
+func (c *countingAgent) Remove(key ssh.PublicKey) error {
+	c.removeCalls++
+	return c.Agent.Remove(key)
+}
+
+func (c *countingAgent) Extension(extensionType string, contents []byte) ([]byte, error) {
+	return nil, ag.ErrExtensionUnsupported
+}
+
+func (c *countingAgent) SignWithFlags(key ssh.PublicKey, data []byte, flags ag.SignatureFlags) (*ssh.Signature, error) {
+	if e, ok := c.Agent.(ag.ExtendedAgent); ok {
+		return e.SignWithFlags(key, data, flags)
+	}
+	return c.Sign(key, data)
+}
+
+func TestServer_remove_skipsForwardForInMemoryHardCert(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	priv, pub, err := createPublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := &ssh.Certificate{
+		Key:         signer.PublicKey(),
+		KeyId:       `{"prins":[],"transID":"deadbeef","reqUser":"","reqIP":"","reqHost":"","isFirefighter":false,"isHWKey":true,"isHeadless":false,"isNonce":false,"touchPolicy":2,"ver":1}`,
+		ValidAfter:  uint64(now.Add(-time.Hour).Unix()),
+		ValidBefore: uint64(now.Add(time.Hour).Unix()),
+	}
+	if err := cert.SignCert(rand.Reader, signer); err != nil {
+		t.Fatal(err)
+	}
+
+	counting := &countingAgent{Agent: ag.NewKeyring()}
+	s := &Server{
+		agent:                  counting,
+		certs:                  make(map[hashcode]*certificate),
+		upstreamSSHCACertCache: make(map[hashcode]struct{}),
+	}
+	if err := counting.Add(ag.AddedKey{PrivateKey: priv}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddHardCert(cert, "suffix"); err != nil {
+		t.Fatal(err)
+	}
+	counting.removeCalls = 0
+
+	if err := s.Remove(cert); err != nil {
+		t.Fatalf("Remove HardCert: %v", err)
+	}
+	if counting.removeCalls != 0 {
+		t.Fatalf("expected no underlying agent.Remove for in-memory HardCert, got %d", counting.removeCalls)
+	}
+	if _, ok := s.certs[hash(cert.Marshal())]; ok {
+		t.Fatal("expected HardCert removed from in-memory map")
+	}
+	keys, err := counting.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 1 || !bytes.Equal(keys[0].Marshal(), pub.Marshal()) {
+		t.Fatalf("expected bare key to remain in underlying agent, got %#v", keys)
+	}
+}
+
+func TestServer_remove_forwardsInAgentIdentityNotInMemory(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	priv, _, err := createPublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := &ssh.Certificate{
+		Key:         signer.PublicKey(),
+		KeyId:       "keyid",
+		ValidAfter:  uint64(now.Add(-time.Hour).Unix()),
+		ValidBefore: uint64(now.Add(time.Hour).Unix()),
+	}
+	if err := cert.SignCert(rand.Reader, signer); err != nil {
+		t.Fatal(err)
+	}
+
+	counting := &countingAgent{Agent: ag.NewKeyring()}
+	s := &Server{
+		agent:                  counting,
+		certs:                  make(map[hashcode]*certificate),
+		upstreamSSHCACertCache: make(map[hashcode]struct{}),
+	}
+	if err := counting.Add(ag.AddedKey{PrivateKey: priv, Certificate: cert, Comment: "in-agent"}); err != nil {
+		t.Fatal(err)
+	}
+	counting.removeCalls = 0
+
+	if err := s.Remove(cert); err != nil {
+		t.Fatalf("Remove in-agent cert: %v", err)
+	}
+	if counting.removeCalls != 1 {
+		t.Fatalf("expected underlying agent.Remove once when identity is not in s.certs, got %d", counting.removeCalls)
+	}
+	keys, err := counting.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected in-agent cert removed, got %#v", keys)
 	}
 }

--- a/agent/shimagent/shimserver_test.go
+++ b/agent/shimagent/shimserver_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"math/big"
 	"sort"
 	"sync"
@@ -1324,10 +1325,14 @@ func TestServer_Sign(t *testing.T) {
 type countingAgent struct {
 	ag.Agent
 	removeCalls int
+	removeErr   error
 }
 
 func (c *countingAgent) Remove(key ssh.PublicKey) error {
 	c.removeCalls++
+	if c.removeErr != nil {
+		return c.removeErr
+	}
 	return c.Agent.Remove(key)
 }
 
@@ -1441,5 +1446,34 @@ func TestServer_remove_forwardsInAgentIdentityNotInMemory(t *testing.T) {
 	}
 	if len(keys) != 0 {
 		t.Fatalf("expected in-agent cert removed, got %#v", keys)
+	}
+}
+
+func TestServer_remove_propagatesUnderlyingRemoveError(t *testing.T) {
+	t.Parallel()
+
+	priv, pub, err := createPublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := errors.New("underlying remove failed")
+	counting := &countingAgent{Agent: ag.NewKeyring(), removeErr: wantErr}
+	s := &Server{
+		agent:                  counting,
+		certs:                  make(map[hashcode]*certificate),
+		upstreamSSHCACertCache: make(map[hashcode]struct{}),
+	}
+	if err := counting.Add(ag.AddedKey{PrivateKey: priv}); err != nil {
+		t.Fatal(err)
+	}
+	counting.removeCalls = 0
+
+	err = s.Remove(pub)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected underlying remove error, got %v", err)
+	}
+	if counting.removeCalls != 1 {
+		t.Fatalf("expected underlying agent.Remove once, got %d", counting.removeCalls)
 	}
 }


### PR DESCRIPTION
## Summary
- HardCerts from `AddHardCert` live only in shimagent memory (`s.certs`), not in the underlying OpenSSH agent.
- On Windows, forwarding `Remove` for those cert identities to the slave agent also dropped the matching PKCS11 bare keys, so a second `yinit -force` failed with `agent: key not found` during `AddHardCert`.
- If the identity is found in `s.certs`, clear it from memory and skip `s.agent.Remove`. Only forward Remove to the slave for identities that are actually stored in-agent.
- macOS was mostly unaffected because slave Remove for these cert blobs typically no-oped; Windows OpenSSH Remove is stricter/side-effecting for PKCS11.
## Test plan
- [ ] Windows: `yinit -oidc -l <user> -force` twice in a row succeeds
- [ ] Windows: after first `-force`, `ssh-add -l` still shows OpenSC PKCS11 bare keys plus HardCerts after second run
- [ ] macOS: repeated `yinit -oidc -l <user> -force` still succeeds